### PR TITLE
Hash the state stored when sending a user to identity provider

### DIFF
--- a/lib/methods/index.js
+++ b/lib/methods/index.js
@@ -2,6 +2,7 @@ const Hoek = require('hoek')
 const url = require('url')
 const debug = require('debug')('defra.identity:methods')
 const uuidv4 = require('uuid/v4')
+const md5 = require('md5')
 
 const registerDynamicsMethods = require('./dynamics')
 
@@ -192,7 +193,8 @@ module.exports = (
       nonce
     }, stateCacheData)
 
-    await cache.set(state, stateCacheData, undefined, request)
+    // If our state is massively long, it could cause an error in cosmos db- hash it so we know it will be short enough
+    await cache.set(md5(state), stateCacheData, undefined, request)
 
     const client = await internals.client.getClient({ policyName })
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -3,6 +3,7 @@ const debug = require('debug')('defra.identity:routes')
 const fs = require('fs')
 const path = require('path')
 const qs = require('querystring')
+const md5 = require('md5')
 
 const postAuthenticationJsFile = fs.readFileSync(path.join(__dirname, 'static', 'postAuthenticationRedirect.js')).toString()
 
@@ -61,7 +62,7 @@ module.exports = (
         /** Get our saved state **/
         const { state } = requestParams
 
-        const [savedStateErr, savedState] = await to(cache.get(state, request))
+        const [savedStateErr, savedState] = await to(cache.get(md5(state), request))
 
         if (!savedState || savedStateErr) {
           const savedStateErrObj = savedStateErr || {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@envage/defra-identity-hapi-plugin",
-  "version": "2.2.8",
+  "version": "2.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -786,6 +786,11 @@
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
       "dev": true
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+    },
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
@@ -1039,6 +1044,11 @@
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "cryptiles": {
       "version": "4.1.1",
@@ -3290,8 +3300,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -4060,6 +4069,16 @@
         "micromatch": "^3.0.4",
         "resolve": "^1.4.0",
         "stack-trace": "0.0.10"
+      }
+    },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "requires": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
       }
     },
     "micromatch": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envage/defra-identity-hapi-plugin",
-  "version": "2.3.5",
+  "version": "2.4.0",
   "description": "A hapi auth plugin to allow easy integration with DEFRA's Identity Management system",
   "repository": {
     "type": "git",
@@ -36,6 +36,7 @@
     "debug": "^3.1.0",
     "hapi-auth-cookie": "^8.1.0",
     "joi": "^13.4.0",
+    "md5": "^2.2.1",
     "openid-client": "^1.20.0",
     "request": "^2.88.0",
     "uuid": "^3.2.1",


### PR DESCRIPTION
If our state is massively long, it could cause an error in cosmos db - hash it so we know it will be short enough

Minor version bump - minor not patch because maybe someone could be accessing the cache directly based on the original state - not the hashed one