### PR TITLE
Enrolment updates

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. 
 
+## 3.0.0 - 19 Dec 2018
+- Remove readContactsEmployerLinks and readContactsAgentCustomerLinks in favour of readContactsAccountLinks
+- - By default, reads links of type: employee, agentCustomer and citizen but accepts overrides for types of roles queried
+- - Allows for easy enrolment of citizen accounts 
+- - Updates to demo to suit the above
+- Remove readContactIdFromB2cObjectId - No longer needed now that contact id is passed back in the token
+
+## 2.6.0 - 18 Dec 2018
+- Add functionality to override scope
+- Allows an access token to be passed back to the relying party
+
 ## 2.5.0 - 21 Nov 2018
 - Fix all npm audit vulnerabilities
 - Added changelog.md

--- a/lib/internals/mappings.js
+++ b/lib/internals/mappings.js
@@ -53,7 +53,8 @@ const roleId = {
   employee: '1eb54ab1-58b7-4d14-bf39-4f3e402616e8',
   employer: '35a23b91-ec62-41ea-b5e5-c59b689ff0b4',
   agent: 'caaf4df7-0229-e811-a831-000d3a2b29f8',
-  agentCustomer: '776e1b5a-1268-e811-a83b-000d3ab4f7af'
+  agentCustomer: '776e1b5a-1268-e811-a83b-000d3ab4f7af',
+  citizen: '3fc7e717-0b90-e811-a845-000d3ab4fddf'
 }
 
 /**

--- a/lib/methods/dynamics/webApi/read.js
+++ b/lib/methods/dynamics/webApi/read.js
@@ -92,45 +92,42 @@ module.exports = (
   }
 
   /**
-   * Fetches a user's contact id from their b2cObjectId
+   * Fetches all citizen links of the passed contact
    *
-   * @param {string} b2cObjectId
-   * @return {Promise<String>}
+   * @param {string} contactId
+   * @param {string|Array|undefined} [accountIds]
+   * @param {string|Array|undefined} [roleIds]
+   * @return {Promise<Array>}
    */
-  const readContactIdFromB2cObjectId = async (b2cObjectId) => {
-    const contactRecords = await readContacts({
-      b2cObjectId
-    })
+  const readContactsAccountLinks = async (contactId, accountIds = undefined, roleIds = undefined) => {
+    const request = await readContactsAccountLinks.buildRequest(contactId, accountIds, roleIds)
 
-    if (contactRecords) {
-      return contactRecords[0].dynamicsContactId
+    const res = await requestPromise(request)
+
+    return readContactsAccountLinks.parseResponse(res)
+  }
+
+  readContactsAccountLinks.buildRequest = async (contactId, accountIds, roleIds) => {
+    const params = {
+      '$filter': `_record1id_value eq ${contactId}`
+    }
+
+    if (roleIds) {
+      roleIds = [].concat(roleIds)
     } else {
-      return null
-    }
-  }
-
-  /**
-   * Fetches all employers of the passed contact
-   *
-   * @param {string} contactId
-   * @param {string} accountId
-   * @return {Promise<Array>}
-   */
-  const readContactsEmployerLinks = async (contactId, accountId) => {
-    const request = await readContactsEmployerLinks.buildRequest(contactId, accountId)
-
-    const res = await requestPromise(request)
-
-    return readContactsEmployerLinks.parseResponse(res, contactId)
-  }
-
-  readContactsEmployerLinks.buildRequest = async (contactId, accountId) => {
-    const params = {
-      '$filter': `_record1id_value eq ${contactId} and _record1roleid_value eq ${mappings.roleId.employee}`
+      roleIds = [
+        mappings.roleId.citizen,
+        mappings.roleId.employee,
+        mappings.roleId.agentCustomer
+      ]
     }
 
-    if (accountId) {
-      params.$filter += ` and _record2id_value eq ${accountId} and _record2roleid_value eq ${mappings.roleId.employer}`
+    params.$filter += ` and ( ${roleIds.map(roleId => `_record1roleid_value eq ${roleId}`).join(' or ')} ) `
+
+    if (accountIds) {
+      accountIds = [].concat(accountIds)
+
+      params.$filter += ` and ( ${accountIds.map(accountId => `_record2id_value eq ${accountId}`).join(' or ')} ) `
     }
 
     const url = buildUrl('/connections', params)
@@ -143,11 +140,11 @@ module.exports = (
     }
   }
 
-  readContactsEmployerLinks.parseResponse = (res, contactId) => {
+  readContactsAccountLinks.parseResponse = (res) => {
     const data = decodeResponse(res)
 
     if (!Array.isArray(data.value)) {
-      throw new Error('readContactsEmployerLinks response has unrecognised JSON')
+      throw new Error('readContactsAccountLinks response has unrecognised JSON')
     }
 
     if (!data || !data.value) {
@@ -155,70 +152,11 @@ module.exports = (
     }
 
     const links = data.value.map(link => {
-      const accountId = link._record1id_value === contactId ? link._record2id_value : link._record1id_value
-
       return {
         connectionId: link.connectionid,
         connectionDetailsId: link._defra_connectiondetailsid_value,
-        accountId
-      }
-    })
-
-    return links
-  }
-
-  /**
-   * Fetches all Agent Customers of the passed contact
-   *
-   * @param {string} contactId
-   * @param {string} accountId
-   * @return {Promise<Array>}
-   */
-  const readContactsAgentCustomerLinks = async (contactId, accountId) => {
-    const request = await readContactsAgentCustomerLinks.buildRequest(contactId, accountId)
-
-    const res = await requestPromise(request)
-
-    return readContactsAgentCustomerLinks.parseResponse(res, contactId)
-  }
-
-  readContactsAgentCustomerLinks.buildRequest = async (contactId, accountId) => {
-    const params = {
-      '$filter': `_record1id_value eq ${contactId} and _record1roleid_value eq ${mappings.roleId.agentCustomer}`
-    }
-
-    if (accountId) {
-      params.$filter += ` and _record2id_value eq ${accountId} and _record2roleid_value eq ${mappings.roleId.agent}`
-    }
-
-    const url = buildUrl('/connections', params)
-    const headers = await buildHeaders()
-
-    return {
-      method: 'GET',
-      url,
-      headers
-    }
-  }
-
-  readContactsAgentCustomerLinks.parseResponse = (res, contactId) => {
-    const data = decodeResponse(res)
-
-    if (!Array.isArray(data.value)) {
-      throw new Error('readContactsAgentCustomerLinks response has unrecognised JSON')
-    }
-
-    if (!data || !data.value) {
-      return
-    }
-
-    const links = data.value.map(link => {
-      const accountId = link._record1id_value === contactId ? link._record2id_value : link._record1id_value
-
-      return {
-        connectionId: link.connectionid,
-        connectionDetailsId: link._defra_connectiondetailsid_value,
-        accountId
+        accountId: link._record2id_value,
+        roleId: link._record1roleid_value
       }
     })
 
@@ -348,11 +286,20 @@ module.exports = (
 
     if (enrolment && Array.isArray(enrolment.value)) {
       enrolment.value.forEach(enrol => {
-        response.roles.push(`${enrol._defra_organisation_value}:${enrol._defra_servicerole_value}:${enrol.defra_enrolmentstatus}`)
+        const orgId = enrol._defra_organisation_value || ''
+        const orgName = enrol['_defra_organisation_value@OData.Community.Display.V1.FormattedValue'] || ''
 
-        response.mappings.push(`${enrol._defra_organisation_value}:${enrol['_defra_organisation_value@OData.Community.Display.V1.FormattedValue']}`)
-        response.mappings.push(`${enrol._defra_servicerole_value}:${enrol['_defra_servicerole_value@OData.Community.Display.V1.FormattedValue']}`)
-        response.mappings.push(`${enrol.defra_enrolmentstatus}:${enrol['defra_enrolmentstatus@OData.Community.Display.V1.FormattedValue']}`)
+        const serviceRoleId = enrol._defra_servicerole_value
+        const serviceRoleName = enrol['_defra_servicerole_value@OData.Community.Display.V1.FormattedValue']
+
+        const enrolmentStatusId = enrol.defra_enrolmentstatus
+        const enrolmentStatusName = enrol['defra_enrolmentstatus@OData.Community.Display.V1.FormattedValue']
+
+        response.roles.push(`${orgId}:${serviceRoleId}:${enrolmentStatusId}`)
+
+        response.mappings.push(`${orgId}:${orgName}`)
+        response.mappings.push(`${serviceRoleId}:${serviceRoleName}`)
+        response.mappings.push(`${enrolmentStatusId}:${enrolmentStatusName}`)
       })
     }
 
@@ -361,9 +308,7 @@ module.exports = (
 
   return {
     readContacts,
-    readContactIdFromB2cObjectId,
-    readContactsEmployerLinks,
-    readContactsAgentCustomerLinks,
+    readContactsAccountLinks,
     readServiceRoles,
     readEnrolment,
     readServiceEnrolment

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envage/defra-identity-hapi-plugin",
-  "version": "2.5.0",
+  "version": "3.0.0",
   "description": "A hapi auth plugin to allow easy integration with DEFRA's Identity Management system",
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -367,19 +367,12 @@ All server methods, with jsdocs can be found in [lib/methods](lib/methods)
 ##### `idm.dynamics.readCompanyNumbers`
 - This will return the companies house id for the organisation id you pass it
 
-##### `idm.dynamics.readContactIdFromB2cObjectId`
-- If you pass your user's `sub` from their claims, this will return the associated dynamics contact id
-
 ##### `idm.dynamics.readContacts`
 - Will query dynamics for users matching the input parameters
 
-##### `idm.dynamics.readContactsEmployerLinks`
-- Queries dynamics for connections from the passed contact id to organisations, with the connection type of employee/employer
-- All users must be linked as an employee to at least one organisation. If this link is missing, then there may be an issue.
-
-##### `idm.dynamics.readContactsAgentCustomerLinks`
-- Queries dynamics for connections from the passed contact id to organisations, with the connection type of agent/agent-customer
-- All users must be linked as an agent-customer to at least one organisation.
+##### `idm.dynamics.readContactsAccountLinks`
+- Queries dynamics for connections from the passed contact id to all associated account
+- All users should be linked to at least one account. If this link is missing, then there may be an issue.
 
 ##### `idm.dynamics.readEnrolment`
 - This will query dynamics for existing enrolments

--- a/test/dynamics/webApi/read.js
+++ b/test/dynamics/webApi/read.js
@@ -381,143 +381,257 @@ describe('Dynamics - read', async () => {
     })
   })
 
-  describe('Read Contacts Employer Links', async () => {
+  describe('Read Contacts Account Links', async () => {
     it('should build correct request using contact id', async () => {
-      const { readContactsEmployerLinks, getToken } = idm.dynamics
+      const { readContactsAccountLinks, getToken } = idm.dynamics
 
       const token = await getToken()
 
-      const request = await readContactsEmployerLinks.buildRequest('c20e6efe-9954-4c5b-a76c-83a5518a1385')
+      const request = await readContactsAccountLinks.buildRequest('c20e6efe-9954-4c5b-a76c-83a5518a1385', ['c20e6efe-9954-4c5b-a76c-83a5518a1386'], 'c20e6efe-9954-4c5b-a76c-83a5518a1387')
 
       const expectedRequest = {
-        'method': 'GET',
-        'url': `${dynamicsRoot}/connections?%24filter=_record1id_value%20eq%20c20e6efe-9954-4c5b-a76c-83a5518a1385%20and%20_record1roleid_value%20eq%201eb54ab1-58b7-4d14-bf39-4f3e402616e8`,
-        'headers': {
-          'Authorization': `Bearer ${token}`,
-          'Accept': 'application/json',
-          'Cache-Control': 'no-cache',
-          'Content-Type': 'application/json; charset=utf-8',
-          'OData-MaxVersion': '4.0',
-          'OData-Version': '4.0',
-          'Prefer': 'odata.maxpagesize=500, odata.include-annotations="*"'
-        }
+        method: 'GET',
+        url: `${dynamicsRoot}/connections?%24filter=_record1id_value%20eq%20c20e6efe-9954-4c5b-a76c-83a5518a1385%20and%20(%20_record1roleid_value%20eq%20c20e6efe-9954-4c5b-a76c-83a5518a1387%20)%20%20and%20(%20_record2id_value%20eq%20c20e6efe-9954-4c5b-a76c-83a5518a1386%20)%20`,
+        headers:
+          {
+            Authorization: `Bearer ${token}`,
+            Accept: 'application/json',
+            'Cache-Control': 'no-cache',
+            'Content-Type': 'application/json; charset=utf-8',
+            'OData-MaxVersion': '4.0',
+            'OData-Version': '4.0',
+            Prefer: 'odata.maxpagesize=500, odata.include-annotations="*"'
+          }
       }
 
       expect(request).to.equal(expectedRequest)
     })
 
-    it('should parse response correctly', async () => {
-      const { readContactsEmployerLinks } = idm.dynamics
+    describe('Response should parse correctly', async () => {
+      it('for a business contact', async () => {
+        const { readContactsAccountLinks } = idm.dynamics
 
-      const apiResponse = {
-        'statusCode': 200,
-        'body': JSON.stringify({
-          '@odata.context': `${dynamicsRoot}/$metadata#connections`,
-          '@Microsoft.Dynamics.CRM.totalrecordcount': -1,
-          '@Microsoft.Dynamics.CRM.totalrecordcountlimitexceeded': false,
-          'value': [{
-            '@odata.etag': 'W/"1072264"',
-            'statecode@OData.Community.Display.V1.FormattedValue': 'Active',
-            'statecode': 0,
-            'statuscode@OData.Community.Display.V1.FormattedValue': 'Active',
-            'statuscode': 1,
-            'createdon@OData.Community.Display.V1.FormattedValue': '17/09/2018 10:18',
-            'createdon': '2018-09-17T10:18:10Z',
-            'ismaster@OData.Community.Display.V1.FormattedValue': 'Yes',
-            'ismaster': true,
-            '_owningteam_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'team',
-            '_owningteam_value': '7d14cfc9-92a8-e811-a953-000d3a39c345',
-            '_relatedconnectionid_value@Microsoft.Dynamics.CRM.associatednavigationproperty': 'relatedconnectionid',
-            '_relatedconnectionid_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'connection',
-            '_relatedconnectionid_value': 'f8935cf4-62ba-e811-a954-000d3a29ba60',
-            '_ownerid_value@OData.Community.Display.V1.FormattedValue': 'Customer-Master-CM-OWNER',
-            '_ownerid_value@Microsoft.Dynamics.CRM.associatednavigationproperty': 'ownerid',
-            '_ownerid_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'team',
-            '_ownerid_value': '7d14cfc9-92a8-e811-a953-000d3a39c345',
-            'name': 'CHRIFT LIMITED',
-            '_record1roleid_value@OData.Community.Display.V1.FormattedValue': 'Employer',
-            '_record1roleid_value@Microsoft.Dynamics.CRM.associatednavigationproperty': 'record1roleid',
-            '_record1roleid_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'connectionrole',
-            '_record1roleid_value': '1eb54ab1-58b7-4d14-bf39-4f3e402616e8',
-            'versionnumber@OData.Community.Display.V1.FormattedValue': '1,072,264',
-            'versionnumber': 1072264,
-            'connectionid': 'f7935cf4-62ba-e811-a954-000d3a29ba60',
-            '_defra_connectiondetailsid_value@OData.Community.Display.V1.FormattedValue': 'CID-0000000002971-17201809-T9X-101810',
-            '_defra_connectiondetailsid_value@Microsoft.Dynamics.CRM.associatednavigationproperty': 'defra_ConnectionDetailsId',
-            '_defra_connectiondetailsid_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'defra_connectiondetails',
-            '_defra_connectiondetailsid_value': '1d945cf4-62ba-e811-a954-000d3a29ba60',
-            '_record2id_value@OData.Community.Display.V1.FormattedValue': 'CHRIFT LIMITED',
-            '_record2id_value@Microsoft.Dynamics.CRM.associatednavigationproperty': 'record2id_account',
-            '_record2id_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'account',
-            '_record2id_value': 'cf8962ee-62ba-e811-a954-000d3a29ba60',
-            'record2objecttypecode@OData.Community.Display.V1.FormattedValue': 'Organisation',
-            'record2objecttypecode': 1,
-            '_modifiedby_value@OData.Community.Display.V1.FormattedValue': 'SA-DEFRA-CM-DEV ID-APP-REG-S2S',
-            '_modifiedby_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'systemuser',
-            '_modifiedby_value': 'f47bfb22-eaa9-e811-a951-000d3a29ba60',
-            'modifiedon@OData.Community.Display.V1.FormattedValue': '17/09/2018 10:18',
-            'modifiedon': '2018-09-17T10:18:11Z',
-            'record1objecttypecode@OData.Community.Display.V1.FormattedValue': 'Contact',
-            'record1objecttypecode': 2,
-            '_createdby_value@OData.Community.Display.V1.FormattedValue': 'SA-DEFRA-CM-DEV ID-APP-REG-S2S',
-            '_createdby_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'systemuser',
-            '_createdby_value': 'f47bfb22-eaa9-e811-a951-000d3a29ba60',
-            '_owningbusinessunit_value@Microsoft.Dynamics.CRM.associatednavigationproperty': 'owningbusinessunit',
-            '_owningbusinessunit_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'businessunit',
-            '_owningbusinessunit_value': '3b9007e4-9e9d-e811-a877-000d3ab17f9f',
-            '_record1id_value@OData.Community.Display.V1.FormattedValue': '123 123',
-            '_record1id_value@Microsoft.Dynamics.CRM.associatednavigationproperty': 'record1id_contact',
-            '_record1id_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'contact',
-            '_record1id_value': '0a0a62f0-62ba-e811-a955-000d3a28d1a0',
-            '_record2roleid_value@OData.Community.Display.V1.FormattedValue': 'Employee',
-            '_record2roleid_value@Microsoft.Dynamics.CRM.associatednavigationproperty': 'record2roleid',
-            '_record2roleid_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'connectionrole',
-            '_record2roleid_value': '35a23b91-ec62-41ea-b5e5-c59b689ff0b4',
-            '_modifiedonbehalfby_value': null,
-            'effectiveend': null,
-            'entityimage_url': null,
-            'importsequencenumber': null,
-            '_createdonbehalfby_value': null,
-            '_owninguser_value': null,
-            'effectivestart': null,
-            'exchangerate': null,
-            'description': null,
-            'entityimageid': null,
-            'entityimage_timestamp': null,
-            'overriddencreatedon': null,
-            'entityimage': null,
-            '_transactioncurrencyid_value': null
-          }]
-        }),
-        'headers': {
-          'cache-control': 'no-cache',
-          'pragma': 'no-cache',
-          'content-type': 'application/json; odata.metadata=minimal',
-          'expires': '-1',
-          'server': '',
-          'x-ms-service-request-id': '070d0aa7-f63d-41ac-9ae5-8e570643c6be',
-          'req_id': '070d0aa7-f63d-41ac-9ae5-8e570643c6be',
-          'x-ms-ratelimit-burst-remaining-xrm-requests': '59997',
-          'x-ms-ratelimit-time-remaining-xrm-requests': '1,797.57',
-          'odata-version': '4.0',
-          'preference-applied': 'odata.include-annotations="*", odata.maxpagesize=500',
-          'date': 'Mon, 17 Sep 2018 16:28:33 GMT',
-          'connection': 'close',
-          'content-length': '4427'
+        const apiResponse = {
+          'statusCode': 200,
+          'body': JSON.stringify({
+            '@odata.context': `${dynamicsRoot}/$metadata#connections`,
+            '@Microsoft.Dynamics.CRM.totalrecordcount': -1,
+            '@Microsoft.Dynamics.CRM.totalrecordcountlimitexceeded': false,
+            'value': [{
+              '@odata.etag': 'W/"1072264"',
+              'statecode@OData.Community.Display.V1.FormattedValue': 'Active',
+              'statecode': 0,
+              'statuscode@OData.Community.Display.V1.FormattedValue': 'Active',
+              'statuscode': 1,
+              'createdon@OData.Community.Display.V1.FormattedValue': '17/09/2018 10:18',
+              'createdon': '2018-09-17T10:18:10Z',
+              'ismaster@OData.Community.Display.V1.FormattedValue': 'Yes',
+              'ismaster': true,
+              '_owningteam_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'team',
+              '_owningteam_value': '7d14cfc9-92a8-e811-a953-000d3a39c345',
+              '_relatedconnectionid_value@Microsoft.Dynamics.CRM.associatednavigationproperty': 'relatedconnectionid',
+              '_relatedconnectionid_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'connection',
+              '_relatedconnectionid_value': 'f8935cf4-62ba-e811-a954-000d3a29ba60',
+              '_ownerid_value@OData.Community.Display.V1.FormattedValue': 'Customer-Master-CM-OWNER',
+              '_ownerid_value@Microsoft.Dynamics.CRM.associatednavigationproperty': 'ownerid',
+              '_ownerid_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'team',
+              '_ownerid_value': '7d14cfc9-92a8-e811-a953-000d3a39c345',
+              'name': 'CHRIFT LIMITED',
+              '_record1roleid_value@OData.Community.Display.V1.FormattedValue': 'Employer',
+              '_record1roleid_value@Microsoft.Dynamics.CRM.associatednavigationproperty': 'record1roleid',
+              '_record1roleid_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'connectionrole',
+              '_record1roleid_value': '1eb54ab1-58b7-4d14-bf39-4f3e402616e8',
+              'versionnumber@OData.Community.Display.V1.FormattedValue': '1,072,264',
+              'versionnumber': 1072264,
+              'connectionid': 'f7935cf4-62ba-e811-a954-000d3a29ba60',
+              '_defra_connectiondetailsid_value@OData.Community.Display.V1.FormattedValue': 'CID-0000000002971-17201809-T9X-101810',
+              '_defra_connectiondetailsid_value@Microsoft.Dynamics.CRM.associatednavigationproperty': 'defra_ConnectionDetailsId',
+              '_defra_connectiondetailsid_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'defra_connectiondetails',
+              '_defra_connectiondetailsid_value': '1d945cf4-62ba-e811-a954-000d3a29ba60',
+              '_record2id_value@OData.Community.Display.V1.FormattedValue': 'CHRIFT LIMITED',
+              '_record2id_value@Microsoft.Dynamics.CRM.associatednavigationproperty': 'record2id_account',
+              '_record2id_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'account',
+              '_record2id_value': 'cf8962ee-62ba-e811-a954-000d3a29ba60',
+              'record2objecttypecode@OData.Community.Display.V1.FormattedValue': 'Organisation',
+              'record2objecttypecode': 1,
+              '_modifiedby_value@OData.Community.Display.V1.FormattedValue': 'SA-DEFRA-CM-DEV ID-APP-REG-S2S',
+              '_modifiedby_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'systemuser',
+              '_modifiedby_value': 'f47bfb22-eaa9-e811-a951-000d3a29ba60',
+              'modifiedon@OData.Community.Display.V1.FormattedValue': '17/09/2018 10:18',
+              'modifiedon': '2018-09-17T10:18:11Z',
+              'record1objecttypecode@OData.Community.Display.V1.FormattedValue': 'Contact',
+              'record1objecttypecode': 2,
+              '_createdby_value@OData.Community.Display.V1.FormattedValue': 'SA-DEFRA-CM-DEV ID-APP-REG-S2S',
+              '_createdby_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'systemuser',
+              '_createdby_value': 'f47bfb22-eaa9-e811-a951-000d3a29ba60',
+              '_owningbusinessunit_value@Microsoft.Dynamics.CRM.associatednavigationproperty': 'owningbusinessunit',
+              '_owningbusinessunit_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'businessunit',
+              '_owningbusinessunit_value': '3b9007e4-9e9d-e811-a877-000d3ab17f9f',
+              '_record1id_value@OData.Community.Display.V1.FormattedValue': '123 123',
+              '_record1id_value@Microsoft.Dynamics.CRM.associatednavigationproperty': 'record1id_contact',
+              '_record1id_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'contact',
+              '_record1id_value': '0a0a62f0-62ba-e811-a955-000d3a28d1a0',
+              '_record2roleid_value@OData.Community.Display.V1.FormattedValue': 'Employee',
+              '_record2roleid_value@Microsoft.Dynamics.CRM.associatednavigationproperty': 'record2roleid',
+              '_record2roleid_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'connectionrole',
+              '_record2roleid_value': '35a23b91-ec62-41ea-b5e5-c59b689ff0b4',
+              '_modifiedonbehalfby_value': null,
+              'effectiveend': null,
+              'entityimage_url': null,
+              'importsequencenumber': null,
+              '_createdonbehalfby_value': null,
+              '_owninguser_value': null,
+              'effectivestart': null,
+              'exchangerate': null,
+              'description': null,
+              'entityimageid': null,
+              'entityimage_timestamp': null,
+              'overriddencreatedon': null,
+              'entityimage': null,
+              '_transactioncurrencyid_value': null
+            }]
+          }),
+          'headers': {
+            'cache-control': 'no-cache',
+            'pragma': 'no-cache',
+            'content-type': 'application/json; odata.metadata=minimal',
+            'expires': '-1',
+            'server': '',
+            'x-ms-service-request-id': '070d0aa7-f63d-41ac-9ae5-8e570643c6be',
+            'req_id': '070d0aa7-f63d-41ac-9ae5-8e570643c6be',
+            'x-ms-ratelimit-burst-remaining-xrm-requests': '59997',
+            'x-ms-ratelimit-time-remaining-xrm-requests': '1,797.57',
+            'odata-version': '4.0',
+            'preference-applied': 'odata.include-annotations="*", odata.maxpagesize=500',
+            'date': 'Mon, 17 Sep 2018 16:28:33 GMT',
+            'connection': 'close',
+            'content-length': '4427'
+          }
         }
-      }
 
-      const expectedParsedResponse = [
-        {
-          'connectionId': 'f7935cf4-62ba-e811-a954-000d3a29ba60',
-          'connectionDetailsId': '1d945cf4-62ba-e811-a954-000d3a29ba60',
-          'accountId': '0a0a62f0-62ba-e811-a955-000d3a28d1a0'
+        const expectedParsedResponse = [{
+          connectionId: 'f7935cf4-62ba-e811-a954-000d3a29ba60',
+          connectionDetailsId: '1d945cf4-62ba-e811-a954-000d3a29ba60',
+          accountId: 'cf8962ee-62ba-e811-a954-000d3a29ba60',
+          roleId: '1eb54ab1-58b7-4d14-bf39-4f3e402616e8'
+        }]
+
+        const parsedResponse = readContactsAccountLinks.parseResponse(apiResponse)
+
+        expect(parsedResponse).to.equal(expectedParsedResponse)
+      })
+
+      it('for a private citizen contact', async () => {
+        const { readContactsAccountLinks } = idm.dynamics
+
+        const apiResponse = {
+          'statusCode': 200,
+          'body': JSON.stringify({
+            '@odata.context': 'https://defra-custmstr-idev.api.crm4.dynamics.com/api/data/v9.0/$metadata#connections',
+            '@Microsoft.Dynamics.CRM.totalrecordcount': -1,
+            '@Microsoft.Dynamics.CRM.totalrecordcountlimitexceeded': false,
+            'value': [{
+              '@odata.etag': 'W/"3044707"',
+              'statecode@OData.Community.Display.V1.FormattedValue': 'Active',
+              'statecode': 0,
+              'statuscode@OData.Community.Display.V1.FormattedValue': 'Active',
+              'statuscode': 1,
+              'createdon@OData.Community.Display.V1.FormattedValue': '18/12/2018 18:15',
+              'createdon': '2018-12-18T18:15:26Z',
+              'ismaster@OData.Community.Display.V1.FormattedValue': 'Yes',
+              'ismaster': true,
+              '_owningteam_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'team',
+              '_owningteam_value': '7d14cfc9-92a8-e811-a953-000d3a39c345',
+              '_relatedconnectionid_value@Microsoft.Dynamics.CRM.associatednavigationproperty': 'relatedconnectionid',
+              '_relatedconnectionid_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'connection',
+              '_relatedconnectionid_value': '37e1e0e0-f002-e911-a960-000d3a28ac31',
+              '_ownerid_value@OData.Community.Display.V1.FormattedValue': 'Customer-Master-CM-OWNER',
+              '_ownerid_value@Microsoft.Dynamics.CRM.associatednavigationproperty': 'ownerid',
+              '_ownerid_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'team',
+              '_ownerid_value': '7d14cfc9-92a8-e811-a953-000d3a39c345',
+              'modifiedon@OData.Community.Display.V1.FormattedValue': '18/12/2018 18:15',
+              'modifiedon': '2018-12-18T18:15:27Z',
+              '_record1roleid_value@OData.Community.Display.V1.FormattedValue': 'Defra Citizen',
+              '_record1roleid_value@Microsoft.Dynamics.CRM.associatednavigationproperty': 'record1roleid',
+              '_record1roleid_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'connectionrole',
+              '_record1roleid_value': '3fc7e717-0b90-e811-a845-000d3ab4fddf',
+              'versionnumber@OData.Community.Display.V1.FormattedValue': '3,044,707',
+              'versionnumber': 3044707,
+              'connectionid': '36e1e0e0-f002-e911-a960-000d3a28ac31',
+              '_defra_connectiondetailsid_value@OData.Community.Display.V1.FormattedValue': 'CDE-0000000016579-18201812-F7L-061527',
+              '_defra_connectiondetailsid_value@Microsoft.Dynamics.CRM.associatednavigationproperty': 'defra_ConnectionDetailsId',
+              '_defra_connectiondetailsid_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'defra_connectiondetails',
+              '_defra_connectiondetailsid_value': '54e1e0e0-f002-e911-a960-000d3a28ac31',
+              'defra_iscustomer@OData.Community.Display.V1.FormattedValue': 'Yes',
+              'defra_iscustomer': true,
+              '_modifiedby_value@OData.Community.Display.V1.FormattedValue': 'SA-DEFRA-CM-IDM ID-APP-REG-S2S',
+              '_modifiedby_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'systemuser',
+              '_modifiedby_value': '63970d21-69b6-e811-a954-000d3a28d1a0',
+              '_createdby_value@OData.Community.Display.V1.FormattedValue': 'SA-DEFRA-CM-IDM ID-APP-REG-S2S',
+              '_createdby_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'systemuser',
+              '_createdby_value': '63970d21-69b6-e811-a954-000d3a28d1a0',
+              'record1objecttypecode@OData.Community.Display.V1.FormattedValue': 'Contact',
+              'record1objecttypecode': 2,
+              '_owningbusinessunit_value@Microsoft.Dynamics.CRM.associatednavigationproperty': 'owningbusinessunit',
+              '_owningbusinessunit_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'businessunit',
+              '_owningbusinessunit_value': '3b9007e4-9e9d-e811-a877-000d3ab17f9f',
+              '_record1id_value@OData.Community.Display.V1.FormattedValue': 'Cheese Man',
+              '_record1id_value@Microsoft.Dynamics.CRM.associatednavigationproperty': 'record1id_contact',
+              '_record1id_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'contact',
+              '_record1id_value': 'd1e0e0e0-f002-e911-a960-000d3a28ac31',
+              '_record2roleid_value@OData.Community.Display.V1.FormattedValue': 'Citizen',
+              '_record2roleid_value@Microsoft.Dynamics.CRM.associatednavigationproperty': 'record2roleid',
+              '_record2roleid_value@Microsoft.Dynamics.CRM.lookuplogicalname': 'connectionrole',
+              '_record2roleid_value': '878ed5f8-0a90-e811-a845-000d3ab4fddf',
+              '_modifiedonbehalfby_value': null,
+              'exchangerate': null,
+              '_defra_previousconnectiondetail_value': null,
+              'overriddencreatedon': null,
+              'effectiveend': null,
+              'entityimage_url': null,
+              'description': null,
+              'effectivestart': null,
+              'record2objecttypecode': null,
+              '_createdonbehalfby_value': null,
+              'entityimage_timestamp': null,
+              '_owninguser_value': null,
+              'entityimage': null,
+              'name': null,
+              '_record2id_value': null,
+              'entityimageid': null,
+              'importsequencenumber': null,
+              '_transactioncurrencyid_value': null
+            }]
+          }),
+          'headers': {
+            'cache-control': 'no-cache',
+            'pragma': 'no-cache',
+            'content-type': 'application/json; odata.metadata=minimal',
+            'expires': '-1',
+            'server': '',
+            'x-ms-service-request-id': '070d0aa7-f63d-41ac-9ae5-8e570643c6be',
+            'req_id': '070d0aa7-f63d-41ac-9ae5-8e570643c6be',
+            'x-ms-ratelimit-burst-remaining-xrm-requests': '59997',
+            'x-ms-ratelimit-time-remaining-xrm-requests': '1,797.57',
+            'odata-version': '4.0',
+            'preference-applied': 'odata.include-annotations="*", odata.maxpagesize=500',
+            'date': 'Mon, 17 Sep 2018 16:28:33 GMT',
+            'connection': 'close',
+            'content-length': '4427'
+          }
         }
-      ]
 
-      const parsedResponse = readContactsEmployerLinks.parseResponse(apiResponse)
+        const expectedParsedResponse = [{
+          connectionId: '36e1e0e0-f002-e911-a960-000d3a28ac31',
+          connectionDetailsId: '54e1e0e0-f002-e911-a960-000d3a28ac31',
+          accountId: null,
+          roleId: '3fc7e717-0b90-e811-a845-000d3ab4fddf'
+        }]
 
-      expect(parsedResponse).to.equal(expectedParsedResponse)
+        const parsedResponse = readContactsAccountLinks.parseResponse(apiResponse)
+
+        expect(parsedResponse).to.equal(expectedParsedResponse)
+      })
     })
   })
 


### PR DESCRIPTION
- Remove readContactsEmployerLinks and readContactsAgentCustomerLinks… in favour of readContactsAccountLinks
- - By default, reads links of type: employee, agentCustomer and citizen but accepts overrides for types of roles queried
- - Allows for easy enrolment of citizen accounts
- Remove readContactIdFromB2cObjectId - No longer needed now that contact id is passed back in the token
- Updates to readme, tests, changelog and demo to suit the above