### PR TITLE
Add secure headers only if isSecure is set.

### DIFF
--- a/demo/server.js
+++ b/demo/server.js
@@ -18,21 +18,23 @@ const serverCache = config.mongoCache.enabled ? [
   }
 ] : undefined
 
+const security = {
+  xframe: 'deny',
+  noSniff: true,
+  hsts: {
+    maxAge: 10454400,
+    includeSubDomains: true,
+    preload: true
+  }
+}
+
 // Create a server with a host and port
 const server = Hapi.server({
   host: config.app.host,
   port: config.app.port,
   cache: serverCache,
   routes: {
-    security: {
-      xframe: 'deny',
-      noSniff: true,
-      hsts: {
-        maxAge: 10454400,
-        includeSubDomains: true,
-        preload: true
-      }
-    },
+    security: config.isSecure === true ? security : false,
     validate: {
       options: {
         abortEarly: false


### PR DESCRIPTION
Switch security headers only when isSecure set to be true

first had in demo/.env  
IS_SECURE=false
then
IS_SECURE=true

![screenshot 2019-01-22 at 11 11 14](https://user-images.githubusercontent.com/43479432/51532123-3acc1a80-1e37-11e9-91bb-6287ca0df98c.png)
