### PR TITLE
Ensure that redirects after logging out are always to the same domain…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file. 
 
+## 4.0.2 - 11 Mar 2019
+- Ensure that redirects after logging out are always to the same domain as the consuming service
+
 ## 4.0.1 - 11 Mar 2019
 - Set sameSite cookie policy to 'Lax' - https://www.owasp.org/index.php/SameSite
 

--- a/lib/internals/routes.js
+++ b/lib/internals/routes.js
@@ -22,7 +22,10 @@ module.exports = (
   }
 
   e.handleAuthorisationError = async (request, h, savedState, authorisationErr) => {
-    const { message: errorMessage, error_description: errorDescription } = authorisationErr
+    const {
+      message: errorMessage,
+      error_description: errorDescription
+    } = authorisationErr
 
     let {
       disallowedRedirectPath
@@ -32,22 +35,22 @@ module.exports = (
       disallowedRedirectPath = config.disallowedRedirectPath
     }
 
-    const errorRedirectPath = url.parse(disallowedRedirectPath)
+    const errorRedirectUrl = url.parse(e.fullyQualifiedLocalPath(disallowedRedirectPath))
 
-    errorRedirectPath.query = {
+    errorRedirectUrl.query = {
+      ...errorRedirectUrl.query, // Maintain any existing query parameters
       errorMessage,
       errorDescription
     }
 
     debug({ authorisationErr })
 
-    return h.redirect(errorRedirectPath.format())
+    return h.redirect(errorRedirectUrl.format())
   }
 
   e.handleValidatedToken = async (request, h, state, savedState, tokenSet) => {
     const {
-      defaultBackToPath,
-      appDomain
+      defaultBackToPath
     } = config
 
     const {
@@ -73,13 +76,7 @@ module.exports = (
       if (preReturnPathRedirectCbOutcome) { return preReturnPathRedirectCbOutcome }
     }
 
-    const parsedBackToPath = backToPath.startsWith('http') ? url.parse(backToPath).pathname : backToPath
-
-    const fqBackToPathUrlObj = url.parse(appDomain)
-
-    fqBackToPathUrlObj.pathname = parsedBackToPath
-
-    const fqBackToPathString = url.format(fqBackToPathUrlObj)
+    const fqBackToPathString = e.fullyQualifiedLocalPath(backToPath)
 
     // Workaround for chrome bug whereby cookies won't set a cookie when a 302 redirect is returned
     // https://github.com/hapijs/hapi-auth-cookie/issues/159
@@ -91,6 +88,20 @@ module.exports = (
         <a href="${fqBackToPathString}">Please click here to continue</a>
       </noscript>`
     )
+  }
+
+  e.fullyQualifiedLocalPath = (path) => {
+    const {
+      appDomain
+    } = config
+
+    const parsedBackToPath = path.startsWith('http') ? url.parse(path).pathname : path
+
+    const fqBackToPathUrlObj = url.parse(appDomain)
+
+    fqBackToPathUrlObj.pathname = parsedBackToPath
+
+    return url.format(fqBackToPathUrlObj)
   }
 
   return e

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -123,10 +123,13 @@ module.exports = (
 
           await server.methods.idm.logout(request)
 
-          const { query } = request
-          const redirPath = query.backToPath || '/'
+          const {
+            backToPath
+          } = request.query
 
-          return h.redirect(redirPath)
+          const redirectUrl = internals.routes.fullyQualifiedLocalPath(backToPath)
+
+          return h.redirect(redirectUrl)
         } catch (e) {
           debug({ e })
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envage/defra-identity-hapi-plugin",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "A hapi auth plugin to allow easy integration with DEFRA's Identity Management system",
   "repository": {
     "type": "git",

--- a/test/internals/routes.js
+++ b/test/internals/routes.js
@@ -1,0 +1,205 @@
+const Lab = require('lab')
+const Code = require('code')
+const lab = exports.lab = Lab.script()
+
+const { describe, it } = lab
+const { expect } = Code
+
+const RouteMethods = require('../../lib/internals/routes')
+
+describe('Internals - routes', () => {
+  describe('storeTokenSetResponse', async () => {
+    it('should store tokenSet in cache and in cookieAuth', async () => {
+      const passed = {
+        cache: {
+          key: null,
+          value: null,
+          ttl: null,
+          request: null
+        },
+        cookieAuth: {
+          value: null
+        }
+      }
+
+      const mock = {
+        request: {
+          cookieAuth: {
+            set: (value) => {
+              passed.cookieAuth.value = value
+            }
+          }
+        },
+        tokenSet: {
+          claims: {
+            sub: Symbol('sub')
+          }
+        },
+        cache: {
+          set: (key, value, ttl, request) => {
+            passed.cache.key = key
+            passed.cache.value = value
+            passed.cache.ttl = ttl
+            passed.cache.request = request
+          }
+        }
+      }
+
+      const routeMethods = RouteMethods({
+        cache: mock.cache
+      })
+
+      const output = await routeMethods.storeTokenSetResponse(mock.request, mock.tokenSet)
+
+      expect(output).to.be.undefined()
+      expect(passed.cache.key).to.equal(mock.tokenSet.claims.sub)
+      expect(passed.cache.value).to.equal({
+        tokenSet: mock.tokenSet,
+        claims: mock.tokenSet.claims
+      })
+      expect(passed.cache.ttl).to.be.undefined()
+      expect(passed.cache.request).to.equal(mock.request)
+
+      expect(passed.cookieAuth.value).to.equal({
+        sub: mock.tokenSet.claims.sub
+      })
+    })
+  })
+
+  describe('handleAuthorisationError', async () => {
+    it('should redirect to full qualified error redirect url with error details in the url', async () => {
+      const mock = {
+        request: Symbol('request'),
+        h: {
+          redirect: (path) => path
+        },
+        savedState: {},
+        authorisationErr: {
+          message: 'error message',
+          error_description: 'error description'
+        },
+        config: {
+          appDomain: 'https://app.domain',
+          disallowedRedirectPath: '/disallowed-redirect-path'
+        }
+      }
+
+      const routeMethods = RouteMethods({
+        config: mock.config
+      })
+
+      const output = await routeMethods.handleAuthorisationError(mock.request, mock.h, mock.savedState, mock.authorisationErr)
+
+      expect(output).to.equal(`${mock.config.appDomain}${mock.config.disallowedRedirectPath}?errorMessage=${encodeURIComponent(mock.authorisationErr.message)}&errorDescription=${encodeURIComponent(mock.authorisationErr.error_description)}`)
+    })
+  })
+
+  describe('handleValidatedToken', async () => {
+    it('should store our token and return a javascript redirect to the final redirect url', async () => {
+      const passed = {
+        cache: {
+          state: null,
+          request: null
+        },
+        preReturnPathRedirect: {
+          request: null,
+          h: null,
+          tokenSet: null,
+          backToPath: null
+        }
+      }
+
+      const mock = {
+        tokenSet: {
+          claims: {
+            sub: Symbol('sub')
+          }
+        },
+        state: Symbol('state'),
+        savedState: {
+          backToPath: undefined
+        },
+        cache: {
+          set: () => {},
+          drop: async (state, request) => {
+            passed.cache.state = state
+            passed.cache.request = request
+          }
+        },
+        config: {
+          defaultBackToPath: '/default-back-to-path',
+          appDomain: 'https://app.domain',
+          callbacks: {
+            preReturnPathRedirect: async (request, h, tokenSet, backToPath) => {
+              passed.preReturnPathRedirect.request = request
+              passed.preReturnPathRedirect.h = h
+              passed.preReturnPathRedirect.tokenSet = tokenSet
+              passed.preReturnPathRedirect.backToPath = backToPath
+            }
+          }
+        },
+        request: {
+          cookieAuth: {
+            set: () => {}
+          }
+        },
+        h: {
+          response: (response) => response
+        }
+      }
+
+      const routeMethods = RouteMethods({
+        config: mock.config,
+        cache: mock.cache
+      })
+
+      const output = await routeMethods.handleValidatedToken(mock.request, mock.h, mock.state, mock.savedState, mock.tokenSet)
+
+      expect(output).to.be.a.string()
+      expect(passed.preReturnPathRedirect).to.equal({
+        request: mock.request,
+        h: mock.h,
+        tokenSet: mock.tokenSet,
+        backToPath: mock.config.defaultBackToPath
+      })
+      expect(passed.cache).to.equal({
+        state: mock.state,
+        request: mock.request
+      })
+    })
+  })
+
+  describe('fullyQualifiedLocalPath', async () => {
+    const mockAppDomain = 'https://app.domain'
+
+    const { fullyQualifiedLocalPath } = RouteMethods({
+      config: {
+        appDomain: mockAppDomain
+      }
+    })
+
+    it('should return a fully qualified url including the passed path', async () => {
+      const mock = {
+        path: 'just-a-path'
+      }
+
+      const output = await fullyQualifiedLocalPath(mock.path)
+
+      expect(output).to.be.a.string()
+      expect(output).to.equal(`${mockAppDomain}/${mock.path}`)
+    })
+
+    it('should return a fully qualified url including the passed path of a passed fully qualified url', async () => {
+      const mockPath = 'just-a-path'
+
+      const mock = {
+        pathWithDomain: `https://another.domain/${mockPath}`
+      }
+
+      const output = await fullyQualifiedLocalPath(mock.pathWithDomain)
+
+      expect(output).to.be.a.string()
+      expect(output).to.equal(`${mockAppDomain}/${mockPath}`)
+    })
+  })
+})

--- a/test/methods/dynamics/index.test.js
+++ b/test/methods/dynamics/index.test.js
@@ -9,7 +9,7 @@ const lab = exports.lab = Lab.script()
 const { describe, it } = lab
 const { expect } = Code
 
-const Server = require('../server')
+const Server = require('../../server')
 
 describe('Dynamics', () => {
   let server

--- a/test/methods/dynamics/webApi/create.test.js
+++ b/test/methods/dynamics/webApi/create.test.js
@@ -9,7 +9,7 @@ const lab = exports.lab = Lab.script()
 const { describe, it } = lab
 const { expect } = Code
 
-const Server = require('../../server')
+const Server = require('../../../server')
 
 describe('Dynamics - create', async () => {
   let server

--- a/test/methods/dynamics/webApi/read.serviceRoles.test.js
+++ b/test/methods/dynamics/webApi/read.serviceRoles.test.js
@@ -8,7 +8,7 @@ const lab = exports.lab = Lab.script()
 const { describe, it } = lab
 const { expect } = Code
 
-const readApi = require('../../../lib/methods/dynamics/webApi/read')
+const readApi = require('../../../../lib/methods/dynamics/webApi/read')
 
 const { readServiceRoles } = readApi({
   server: {},

--- a/test/methods/dynamics/webApi/read.test.js
+++ b/test/methods/dynamics/webApi/read.test.js
@@ -9,7 +9,7 @@ const lab = exports.lab = Lab.script()
 const { describe, it } = lab
 const { expect } = Code
 
-const Server = require('../../server')
+const Server = require('../../../server')
 
 describe('Dynamics - read', async () => {
   let server

--- a/test/methods/dynamics/webApi/update.test.js
+++ b/test/methods/dynamics/webApi/update.test.js
@@ -9,7 +9,7 @@ const lab = exports.lab = Lab.script()
 const { describe, it } = lab
 const { expect } = Code
 
-const Server = require('../../server')
+const Server = require('../../../server')
 
 describe('Dynamics - update', async () => {
   let server


### PR DESCRIPTION
… as the consuming service

Tests for all internal methods
Make test directory structure mirror the lib directory