### PR TITLE
IDM-1727 Update entity path when getting cacheKey from request's state

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file. 
 
+## 4.1.0 - 25 Apr 2019
+- IDM-1727 - Update entity path when getting cacheKey from request's state
+
 ## 4.1.0 - 10 Apr 2019
 - IDM-1919 - Add deactivateEnrolment functionality
 

--- a/lib/internals/routes.js
+++ b/lib/internals/routes.js
@@ -13,7 +13,8 @@ module.exports = (
   const e = {}
 
   e.storeTokenSetResponse = async (request, tokenSet) => {
-    const cacheKey = _.get(request, 'auth.artifacts.cacheKey', uuid())
+    const defaultValue = uuid()
+    const cacheKey = _.get(request, ['state', config.cookieName, 'cacheKey'], defaultValue)
 
     await cache.set(cacheKey, {
       tokenSet,


### PR DESCRIPTION
Fix bug where refreshing the token doesn't stop the user being unauthorised.