### PR TITLE
Fix to refreshing the token for the second time since registration

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file. 
 
+## 4.1.3 - 14 Jun 2019
+- IDM-2135 - Fix to refreshing the token for the second time since registration
+
 ## 4.1.1 - 25 Apr 2019
 - IDM-1727 - Update entity path when getting cacheKey from request's state
 

--- a/lib/methods/index.js
+++ b/lib/methods/index.js
@@ -12,8 +12,12 @@ module.exports = (
     cache,
     config,
     internals
-  }) => {
+  }, modules = { registerDynamicsMethods }) => {
   debug('Registering server methods...')
+
+  const {
+    registerDynamicsMethods
+  } = modules
 
   /**
    * Gets the user's session credentials - i.e. refresh token, expiry times of credentials
@@ -124,38 +128,43 @@ module.exports = (
    *
    * @param {object} request - hapi request object
    * @param {String} [contactId] - manually specify user's contact id in case it wasn't present in the original token
+   * @param {Object} modules
    */
-  const refreshToken = async (request, contactId = undefined) => {
-    const creds = await getCredentials(request)
-    const { claims } = creds
+  const refreshToken = async (request, contactId, modules = { getCredentials }) => {
+    const {
+      getCredentials
+    } = modules
+
+    const existingCredentials = await getCredentials(request)
+    const { claims } = existingCredentials
 
     const client = await internals.client.getClient({ policyName: claims.tfp || claims.acr })
 
-    const refreshToken = creds.tokenSet.refresh_token
+    const refreshToken = existingCredentials.tokenSet.refresh_token
 
-    const tokenSet = await client.refresh(refreshToken)
+    const refreshedTokenSet = await client.refresh(refreshToken)
 
-    // If we had no contact id specified, then use the ones from the original tokem
-    contactId = contactId || tokenSet.claims.contactId
+    // Use the contact id passed in, or the one returned in the refresh, or the one we originally had
+    contactId = contactId || refreshedTokenSet.claims.contactId || existingCredentials.claims.contactId
 
     // We still won't have a contact id if they haven't completed registration yet
     if (contactId) {
       const serviceRoles = await server.methods.idm.dynamics.readServiceEnrolment(config.serviceId, contactId)
 
-      tokenSet.claims.roles = serviceRoles.roles
-      tokenSet.claims.roleMappings = serviceRoles.mappings
+      refreshedTokenSet.claims.roles = serviceRoles.roles
+      refreshedTokenSet.claims.roleMappings = serviceRoles.mappings
 
       // If our original token didn't have a contact id then our refreshed one won't either - stick the contact id back in
-      if (!tokenSet.claims.contactId) {
-        tokenSet.claims.contactId = contactId
+      if (!refreshedTokenSet.claims.contactId) {
+        refreshedTokenSet.claims.contactId = contactId
       }
     }
 
     // @todo handle failed/rejected refresh
-    await internals.routes.storeTokenSetResponse(request, tokenSet)
+    await internals.routes.storeTokenSetResponse(request, refreshedTokenSet)
 
-    debug('refreshed and validated tokens %j', tokenSet)
-    debug('refreshed id_token claims %j', tokenSet.claims)
+    debug('refreshed and validated tokens %j', refreshedTokenSet)
+    debug('refreshed id_token claims %j', refreshedTokenSet.claims)
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envage/defra-identity-hapi-plugin",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "description": "A hapi auth plugin to allow easy integration with DEFRA's Identity Management system",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Wasn't using contact id from old token if refreshed token didn't include contact id
Associated tests
Changelog
Patch version bump