### PR TITLE
Bugfix/idm 389 md5 state

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "standard"
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,0 @@
-{
-  "extends": "standard"
-}

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ coverage.lcov
 Dockerfile
 docker-compose.yml
 start.sh
+.idea

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## 4.1.10 - 29 Jan 2020
+- IDM-389 - Fix to pass correctly hashed state to cache drop function
+
 ## 4.1.9 - 19 Sept 2019
 - IDM-2625
   - Addition of EnrolmentRequest read functionality

--- a/lib/internals/routes.js
+++ b/lib/internals/routes.js
@@ -2,6 +2,7 @@ const debug = require('debug')('defra.identity:internals:routes')
 const url = require('url')
 const uuid = require('uuid/v4')
 const _ = require('lodash')
+const md5 = require('md5')
 
 module.exports = (
   {
@@ -69,7 +70,7 @@ module.exports = (
 
     // Get rid of the cache entry containing our state details
     // We don't need it anymore now that authentication has been fulfilled
-    await cache.drop(state, request)
+    await cache.drop(md5(state), request)
 
     // Store our token set response in our cache, with a reference to it in a cookie
     // @todo use the state uid to reference this cache entry - exposes sub id in its current guise

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@envage/defra-identity-hapi-plugin",
-  "version": "4.1.9",
+  "version": "4.1.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envage/defra-identity-hapi-plugin",
-  "version": "4.1.9",
+  "version": "4.1.10",
   "description": "A hapi auth plugin to allow easy integration with DEFRA's Identity Management system",
   "repository": {
     "type": "git",

--- a/test/internals/routes.js
+++ b/test/internals/routes.js
@@ -1,5 +1,6 @@
 const Lab = require('lab')
 const Code = require('code')
+const md5 = require('md5')
 const lab = exports.lab = Lab.script()
 
 const { describe, it } = lab
@@ -220,7 +221,7 @@ describe('Internals - routes', () => {
         backToPath: mock.config.defaultBackToPath
       })
       expect(passed.cache).to.equal({
-        state: mock.state,
+        state: md5(mock.state),
         request: mock.request
       })
     })


### PR DESCRIPTION
- IDM-389 - Fix to pass correctly hashed state to cache drop function
