### PR TITLE
Pre release

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 5.2.6 - 3 Mar 2021
+- CIDM-2176
+  - Add ability to be able to pass a _ga parameter into the outbound url generation mechanisms to facilitate cross site tracking 
+
 ## 5.2.5 - 14 Jan 2021
 - CIDM-1982
   - Add ability to suppress login screen if user already has a valid session on the identity provider

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 5.2.4 - 14 Jan 2021
+- CIDM-1982
+  - Add ability to suppress login screen if user already has a valid session on the identity provider
+
 ## 5.2.3 - 6 Oct 2020
 - CIDM-1468
   - Retry failed B2C requests - only throw error after iteration limit is hit

--- a/lib/methods/index.js
+++ b/lib/methods/index.js
@@ -180,8 +180,10 @@ module.exports = (
    * @param {String} options.serviceId Manually specify consuming service id
    * @param {String} options.nonce Manually specify nonce
    * @param {String} options.scope Manually specify scope
+   * @param {string} options.prompt - Manually set prompt
+   * @returns {string}
    */
-  const generateOutboundRedirectUrl = async (request, { backToPath = '', policyName = '', forceLogin = false, journey = '' }, { state = '', stateCacheData = {}, redirectUri = '', clientId = '', serviceId = '', nonce = '', scope = '' } = {}) => {
+  const generateOutboundRedirectUrl = async (request, { backToPath = '', policyName = '', forceLogin = false, journey = '' }, { state = '', stateCacheData = {}, redirectUri = '', clientId = '', serviceId = '', nonce = '', scope = '', prompt = '' } = {}) => {
     policyName = policyName || config.defaultPolicy
     journey = journey || config.defaultJourney
     state = state || uuidv4()
@@ -213,7 +215,7 @@ module.exports = (
       redirect_uri: redirectUri,
       scope,
       state,
-      prompt: forceLogin ? 'login' : undefined,
+      prompt: forceLogin ? 'login' : prompt || undefined,
       response_type: 'code',
       response_mode: 'form_post',
       client_id: clientId,

--- a/lib/methods/index.js
+++ b/lib/methods/index.js
@@ -76,8 +76,9 @@ module.exports = (
    * @param {String} obj.state - Manually specify the state string to use
    * @param {String} obj.nonce - Manually specify the nonce string to use
    * @param {String} obj.scope - Manually specify the scope string to use
+   * @param {String} obj._ga - Manually specify a cross site google analytics client id
    */
-  const generateAuthenticationUrl = (backToPath, { policyName = '', journey = '', forceLogin = false, returnUrlObject = false, state = '', nonce = '', scope = '' } = {}) => {
+  const generateAuthenticationUrl = (backToPath, { policyName = '', journey = '', forceLogin = false, returnUrlObject = false, state = '', nonce = '', scope = '', _ga = '' } = {}) => {
     backToPath = backToPath || config.defaultBackToPath
 
     const outboundUrl = new URL(config.appDomain)
@@ -91,7 +92,8 @@ module.exports = (
       forceLogin: forceLogin ? 'yes' : '',
       state,
       nonce,
-      scope
+      scope,
+      _ga
     }).toString())
 
     if (returnUrlObject) { return outboundUrl }
@@ -184,7 +186,7 @@ module.exports = (
    * @param {string} options.prompt - Manually set prompt
    * @returns {string}
    */
-  const generateOutboundRedirectUrl = async (request, { backToPath = '', policyName = '', forceLogin = false, journey = '' }, { state = '', stateCacheData = {}, redirectUri = '', clientId = '', serviceId = '', nonce = '', scope = '', prompt = '' } = {}) => {
+  const generateOutboundRedirectUrl = async (request, { backToPath = '', policyName = '', forceLogin = false, journey = '', _ga = '' }, { state = '', stateCacheData = {}, redirectUri = '', clientId = '', serviceId = '', nonce = '', scope = '', prompt = '' } = {}) => {
     policyName = policyName || config.defaultPolicy
     journey = journey || config.defaultJourney
     state = state || uuidv4()
@@ -223,7 +225,8 @@ module.exports = (
       policyName,
       journey,
       serviceId,
-      nonce
+      nonce,
+      _ga
     })
 
     return authorizationUrl

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -27,12 +27,13 @@ module.exports = (
         const { query } = request
 
         // We might have had a state or nonce manually passed through in our url
-        const { state, nonce, scope } = query
+        const { state, nonce, scope, prompt } = query
 
         const outboundUrl = await server.methods.idm.generateOutboundRedirectUrl(request, request.query, {
           state,
           nonce,
-          scope
+          scope,
+          prompt
         })
 
         return h.redirect(outboundUrl)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@envage/defra-identity-hapi-plugin",
-  "version": "5.2.3",
+  "version": "5.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envage/defra-identity-hapi-plugin",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "description": "A hapi auth plugin to allow easy integration with DEFRA's Identity Management system",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envage/defra-identity-hapi-plugin",
-  "version": "5.2.5",
+  "version": "5.2.6",
   "description": "A hapi auth plugin to allow easy integration with DEFRA's Identity Management system",
   "repository": {
     "type": "git",

--- a/test/unit/methods/index.test.js
+++ b/test/unit/methods/index.test.js
@@ -160,6 +160,9 @@ describe('Methods', () => {
           clear: () => {
             passed.cookieAuthClear.called = true
           }
+        },
+        query: {
+          _ga: uuid()
         }
       },
       cacheData: {},
@@ -240,10 +243,14 @@ describe('Methods', () => {
 
   describe('generateAuthenticationUrl', () => {
     beforeEach(() => {
-      outcome = passed.methods['idm.generateAuthenticationUrl'](null, { returnUrlObject: true })
-    })
+      outcome = passed.methods['idm.generateAuthenticationUrl'](null, {
+        returnUrlObject: true,
+        _ga: mock.request.query._ga
+      })
 
-    it('should return a url object', () => expect(outcome).to.be.an.instanceOf(URL))
+      it('should return a url object', () => expect(outcome).to.be.an.instanceOf(URL))
+      it('should include the _ga parameter', () => expect(outcome.searchParams._ga).to.equal(mock.request.query._ga))
+    })
   })
 
   describe('logout', () => {
@@ -312,7 +319,7 @@ describe('Methods', () => {
     beforeEach(async () => {
       state = uuid()
 
-      outcome = await passed.methods['idm.generateOutboundRedirectUrl'](mock.request, {}, { state })
+      outcome = await passed.methods['idm.generateOutboundRedirectUrl'](mock.request, { _ga: mock.request.query._ga }, { state })
     })
 
     it('should set the state in cache', () => expect(passed.cacheSet).to.equal({
@@ -341,7 +348,8 @@ describe('Methods', () => {
       policyName: mock.config.defaultPolicy,
       journey: mock.config.defaultJourney,
       serviceId: mock.config.serviceId,
-      nonce: undefined
+      nonce: undefined,
+      _ga: mock.request.query._ga
     }))
   })
 })


### PR DESCRIPTION
## 5.2.6 - 3 Mar 2021
- CIDM-2176
  - Add ability to be able to pass a _ga parameter into the outbound url generation mechanisms to facilitate cross site tracking 

## 5.2.5 - 14 Jan 2021
- CIDM-1982
  - Add ability to suppress login screen if user already has a valid session on the identity provider